### PR TITLE
Add Ollama provider, secondary/tertiary provider fallback, configurable poll interval, and direct execution mode

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use tokio::sync::{Mutex, Notify, RwLock};
 use tracing::{info, warn};
 
-use crate::config::{LimitsConfig, McpConfig};
+use crate::config::{LimitsConfig, McpConfig, DefaultConfig};
 use crate::persistence::Database;
 use crate::provider::{self, ChatMessage, Provider};
 
@@ -113,6 +113,7 @@ pub struct AgentManager {
     agents: RwLock<HashMap<u64, Arc<Mutex<AgentHandle>>>>,
     next_id: Mutex<u64>,
     limits: LimitsConfig,
+    defaults: DefaultConfig,
     providers: RwLock<HashMap<String, Arc<dyn Provider>>>,
     db: Arc<Database>,
 }
@@ -137,6 +138,7 @@ impl AgentManager {
             agents: RwLock::new(HashMap::new()),
             next_id: Mutex::new(next_id),
             limits: config.limits.clone(),
+            defaults: config.default.clone(),
             providers: RwLock::new(providers),
             db,
         })
@@ -165,18 +167,29 @@ impl AgentManager {
         }
 
         // Determine provider and model
-        let provider_name = if let Some(p) = req.provider.clone() {
-            p
-        } else {
-            let providers = self.providers.read().await;
-            providers.keys().next().cloned().unwrap_or_default()
-        };
+        let provider_name = req
+            .provider
+            .clone()
+            .unwrap_or_else(|| self.defaults.provider.clone());
 
         let providers = self.providers.read().await;
         let provider_arc = providers
             .get(&provider_name)
             .ok_or_else(|| anyhow::anyhow!("Provider '{provider_name}' not configured"))?
             .clone();
+
+        // Build fallback provider chain (secondary, tertiary)
+        let mut fallback_providers: Vec<Arc<dyn Provider>> = Vec::new();
+        if let Some(ref sec) = self.defaults.secondary_provider {
+            if let Some(p) = providers.get(sec) {
+                fallback_providers.push(p.clone());
+            }
+        }
+        if let Some(ref ter) = self.defaults.tertiary_provider {
+            if let Some(p) = providers.get(ter) {
+                fallback_providers.push(p.clone());
+            }
+        }
 
         let model = req
             .model
@@ -280,7 +293,7 @@ impl AgentManager {
         let agent_handle = handle.clone();
         let db = self.db.clone();
         tokio::spawn(async move {
-            run_agent_loop(agent_handle, provider_arc, db).await;
+            run_agent_loop(agent_handle, provider_arc, fallback_providers, db).await;
         });
 
         info!("Spawned agent {id} with task: {}", req.task);
@@ -465,8 +478,9 @@ impl AgentManager {
         Ok(())
     }
 
-    /// Wait for an agent to reach a terminal state, polling every 500ms.
+    /// Wait for an agent to reach a terminal state, polling at the configured interval.
     pub async fn wait_for_completion(&self, id: u64) -> Result<AgentInfo> {
+        let poll_ms = self.limits.agent_poll_interval_ms;
         loop {
             let info = self.get_status(id).await?;
             match info.status {
@@ -474,7 +488,7 @@ impl AgentManager {
                     return Ok(info);
                 }
                 _ => {
-                    tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                    tokio::time::sleep(std::time::Duration::from_millis(poll_ms)).await;
                 }
             }
         }
@@ -503,9 +517,11 @@ impl AgentManager {
 }
 
 /// The main agent execution loop.
+/// Tries the primary provider first; on failure, attempts fallback providers in order.
 async fn run_agent_loop(
     handle: Arc<Mutex<AgentHandle>>,
     provider: Arc<dyn Provider>,
+    fallback_providers: Vec<Arc<dyn Provider>>,
     db: Arc<Database>,
 ) {
     let (messages, system_prompt, agent_id) = {
@@ -517,11 +533,12 @@ async fn run_agent_loop(
         )
     };
 
-    let sys = if system_prompt.is_empty() {
+    let sys_owned = if system_prompt.is_empty() {
         None
     } else {
-        Some(system_prompt.as_str())
+        Some(system_prompt.clone())
     };
+    let sys = sys_owned.as_deref();
 
     {
         let mut h = handle.lock().await;
@@ -538,60 +555,102 @@ async fn run_agent_loop(
         None,
     );
 
-    match provider.chat(&messages, sys).await {
-        Ok(resp) => {
+    // Build the ordered list of providers to try: primary first, then fallbacks
+    let mut providers_to_try: Vec<Arc<dyn Provider>> = vec![provider];
+    providers_to_try.extend(fallback_providers);
+
+    let mut last_error: Option<String> = None;
+    let mut success = false;
+
+    for (idx, prov) in providers_to_try.iter().enumerate() {
+        if idx > 0 {
+            // Update phase to indicate fallback attempt
+            let phase = format!("retrying-provider-{idx}");
             let mut h = handle.lock().await;
             if h.info.status == AgentStatus::Killed {
                 return;
             }
-            h.info.last_output = Some(resp.content.clone());
-            h.info.last_output_tokens = resp.tokens_used;
-            h.info.messages.push(ChatMessage {
-                role: "assistant".into(),
-                content: resp.content.clone(),
-            });
-            h.info.progress = 1.0;
-            h.info.phase = Some("completed".into());
-            h.info.status = AgentStatus::Completed;
-
-            // Persist to database
+            h.info.phase = Some(phase.clone());
             let _ = db.update_agent_status(
                 agent_id,
-                &AgentStatus::Completed,
-                Some("completed"),
-                1.0,
-                Some(&resp.content),
-                resp.tokens_used,
+                &AgentStatus::Running,
+                Some(&phase),
+                0.1,
+                None,
+                None,
                 None,
             );
-            let seq = h.info.messages.len() - 1;
-            let _ = db.insert_message(agent_id, seq, h.info.messages.last().unwrap());
-
-            if let Err(e) = write_agent_log(&h.info) {
-                warn!("Failed to write agent log: {e}");
-            }
+            info!(
+                "Agent {agent_id}: primary provider failed, trying fallback provider '{}'",
+                prov.name()
+            );
         }
-        Err(e) => {
-            let mut h = handle.lock().await;
-            if h.info.status != AgentStatus::Killed {
-                h.info.status = AgentStatus::Failed;
-                h.info.phase = Some("failed".into());
-                h.info.last_output = Some(format!("Error: {e}"));
 
-                // Persist to database
+        match prov.chat(&messages, sys).await {
+            Ok(resp) => {
+                let mut h = handle.lock().await;
+                if h.info.status == AgentStatus::Killed {
+                    return;
+                }
+                h.info.last_output = Some(resp.content.clone());
+                h.info.last_output_tokens = resp.tokens_used;
+                h.info.provider = prov.name().to_string();
+                h.info.messages.push(ChatMessage {
+                    role: "assistant".into(),
+                    content: resp.content.clone(),
+                });
+                h.info.progress = 1.0;
+                h.info.phase = Some("completed".into());
+                h.info.status = AgentStatus::Completed;
+
                 let _ = db.update_agent_status(
                     agent_id,
-                    &AgentStatus::Failed,
-                    Some("failed"),
-                    h.info.progress,
-                    Some(&format!("Error: {e}")),
+                    &AgentStatus::Completed,
+                    Some("completed"),
+                    1.0,
+                    Some(&resp.content),
+                    resp.tokens_used,
                     None,
-                    Some(&e.to_string()),
                 );
+                let seq = h.info.messages.len() - 1;
+                let _ = db.insert_message(agent_id, seq, h.info.messages.last().unwrap());
 
                 if let Err(e) = write_agent_log(&h.info) {
                     warn!("Failed to write agent log: {e}");
                 }
+                success = true;
+                break;
+            }
+            Err(e) => {
+                warn!(
+                    "Agent {agent_id}: provider '{}' failed: {e}",
+                    prov.name()
+                );
+                last_error = Some(e.to_string());
+            }
+        }
+    }
+
+    if !success {
+        let err_msg = last_error.unwrap_or_else(|| "Unknown error".into());
+        let mut h = handle.lock().await;
+        if h.info.status != AgentStatus::Killed {
+            h.info.status = AgentStatus::Failed;
+            h.info.phase = Some("failed".into());
+            h.info.last_output = Some(format!("Error: {err_msg}"));
+
+            let _ = db.update_agent_status(
+                agent_id,
+                &AgentStatus::Failed,
+                Some("failed"),
+                h.info.progress,
+                Some(&format!("Error: {err_msg}")),
+                None,
+                Some(&err_msg),
+            );
+
+            if let Err(e) = write_agent_log(&h.info) {
+                warn!("Failed to write agent log: {e}");
             }
         }
     }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -342,9 +342,9 @@ pub enum ConfigCommands {
     /// Validate the current configuration
     Validate,
 
-    /// Set a default value (role, tool)
+    /// Set a default value (role, tool, secondary-provider, secondary-model, tertiary-provider, tertiary-model, poll-interval)
     SetDefault {
-        /// Key to set (role, tool)
+        /// Key to set (role, tool, secondary-provider, secondary-model, tertiary-provider, tertiary-model, poll-interval)
         key: String,
 
         /// Value to set

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -21,6 +21,18 @@ pub struct McpConfig {
 pub struct DefaultConfig {
     pub provider: String,
     pub model: String,
+    /// Secondary provider (fallback if primary fails).
+    #[serde(default)]
+    pub secondary_provider: Option<String>,
+    /// Default model for the secondary provider.
+    #[serde(default)]
+    pub secondary_model: Option<String>,
+    /// Tertiary provider (fallback if primary and secondary fail).
+    #[serde(default)]
+    pub tertiary_provider: Option<String>,
+    /// Default model for the tertiary provider.
+    #[serde(default)]
+    pub tertiary_model: Option<String>,
     /// Default role to use when spawning agents without --role.
     #[serde(default)]
     pub role: Option<String>,
@@ -34,6 +46,10 @@ impl Default for DefaultConfig {
         Self {
             provider: "openai".into(),
             model: "gpt-4o".into(),
+            secondary_provider: None,
+            secondary_model: None,
+            tertiary_provider: None,
+            tertiary_model: None,
             role: None,
             tool: None,
         }
@@ -81,6 +97,10 @@ pub struct LimitsConfig {
     pub max_children_per_parent: u32,
     #[serde(default = "default_timeout")]
     pub agent_timeout_sec: u64,
+    /// How often agents report status when waiting for completion (milliseconds).
+    /// Default: 60000 (1 minute).
+    #[serde(default = "default_poll_interval_ms")]
+    pub agent_poll_interval_ms: u64,
 }
 
 fn default_max_concurrent() -> u32 {
@@ -95,6 +115,9 @@ fn default_max_children() -> u32 {
 fn default_timeout() -> u64 {
     600
 }
+fn default_poll_interval_ms() -> u64 {
+    60_000
+}
 
 impl Default for LimitsConfig {
     fn default() -> Self {
@@ -103,6 +126,7 @@ impl Default for LimitsConfig {
             max_depth: default_max_depth(),
             max_children_per_parent: default_max_children(),
             agent_timeout_sec: default_timeout(),
+            agent_poll_interval_ms: default_poll_interval_ms(),
         }
     }
 }
@@ -222,6 +246,7 @@ pub fn infer_provider_type(name: &str) -> String {
         "nvidia_nim" | "nvidia-nim" | "nim" => "nvidia_nim".into(),
         "huggingface" | "hf" => "huggingface".into(),
         "bedrock" | "aws" | "amazon" => "bedrock".into(),
+        "ollama" => "ollama".into(),
         _ => "openai_compatible".into(),
     }
 }
@@ -233,6 +258,7 @@ pub fn infer_provider_url(provider_type: &str) -> Option<String> {
         "anthropic" => Some("https://api.anthropic.com/v1".into()),
         "nvidia_nim" | "nvidia-nim" => Some("https://integrate.api.nvidia.com/v1".into()),
         "huggingface" | "hf" => Some("https://api-inference.huggingface.co/models".into()),
+        "ollama" => Some("http://localhost:11434".into()),
         _ => None,
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,10 +19,36 @@ use crate::cli::*;
 use crate::config::{ensure_dirs, load_config};
 use crate::role::RoleDefinition;
 
+/// Known subcommands — used to detect direct-prompt mode.
+const KNOWN_SUBCOMMANDS: &[&str] = &[
+    "spawn", "status", "agent", "agents", "role", "config",
+    "provider", "tool", "workflow", "server", "logs", "diagnose", "alias",
+];
+
+/// Returns true if the process args indicate direct-prompt mode:
+/// i.e. the first non-flag argument is not a known subcommand.
+fn is_direct_mode() -> bool {
+    let args: Vec<String> = std::env::args().collect();
+    let first = args.iter().skip(1).find(|a| !a.starts_with('-'));
+    match first {
+        Some(f) => !KNOWN_SUBCOMMANDS.contains(&f.as_str()),
+        None => false,
+    }
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     logging::init_logging()?;
     ensure_dirs()?;
+
+    // Direct-prompt mode: mastercontrolprogram "some task" [--role X] [--model X] [--provider X]
+    if is_direct_mode() {
+        let config = load_config()?;
+        let db = Arc::new(persistence::Database::open()?);
+        let manager = Arc::new(AgentManager::new(&config, db)?);
+        let exit_code = run_direct_prompt(&manager, &config).await;
+        std::process::exit(exit_code);
+    }
 
     let cli = Cli::parse();
     let config = load_config()?;
@@ -509,6 +535,129 @@ async fn main() -> Result<()> {
     std::process::exit(exit_code);
 }
 
+/// Run a prompt directly without a subcommand.
+/// Syntax: mastercontrolprogram "task" [--role NAME] [--model ID] [--provider NAME] [--json]
+/// Prints only the agent output to stdout and exits.
+async fn run_direct_prompt(manager: &AgentManager, config: &config::McpConfig) -> i32 {
+    let raw: Vec<String> = std::env::args().collect();
+
+    // Parse simple flags from raw args
+    let mut role: Option<String> = None;
+    let mut model: Option<String> = None;
+    let mut provider: Option<String> = None;
+    let mut json_output = config.cli.json_output;
+    let mut task_parts: Vec<String> = Vec::new();
+
+    let mut i = 1usize;
+    while i < raw.len() {
+        match raw[i].as_str() {
+            "--json" => {
+                json_output = true;
+            }
+            "--role" => {
+                i += 1;
+                if i < raw.len() {
+                    role = Some(raw[i].clone());
+                }
+            }
+            "--model" => {
+                i += 1;
+                if i < raw.len() {
+                    model = Some(raw[i].clone());
+                }
+            }
+            "--provider" => {
+                i += 1;
+                if i < raw.len() {
+                    provider = Some(raw[i].clone());
+                }
+            }
+            arg if arg.starts_with("--role=") => {
+                role = Some(arg["--role=".len()..].to_string());
+            }
+            arg if arg.starts_with("--model=") => {
+                model = Some(arg["--model=".len()..].to_string());
+            }
+            arg if arg.starts_with("--provider=") => {
+                provider = Some(arg["--provider=".len()..].to_string());
+            }
+            arg if !arg.starts_with('-') => {
+                task_parts.push(arg.to_string());
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+
+    let task = task_parts.join(" ");
+    if task.is_empty() {
+        eprintln!("Error: no task provided");
+        return 1;
+    }
+
+    // Resolve role
+    let mut sys_prompt: Option<String> = None;
+    let mut resolved_model = model;
+    let mut resolved_provider = provider;
+    let mut resolved_soul: Option<String> = None;
+    let mut resolved_role_name = role.clone();
+
+    if let Some(ref rn) = role {
+        if let Ok(role_def) = role::get_role(rn) {
+            sys_prompt = Some(role::resolve_system_prompt(&role_def).unwrap_or_default());
+            if resolved_model.is_none() {
+                resolved_model = role_def.default_model;
+            }
+            if resolved_provider.is_none() {
+                resolved_provider = role_def.default_provider;
+            }
+            resolved_soul = role_def.soul;
+            resolved_role_name = Some(role_def.role.unwrap_or(rn.clone()));
+        }
+    }
+
+    let req = SpawnRequest {
+        task,
+        role: resolved_role_name,
+        soul: resolved_soul,
+        model: resolved_model,
+        provider: resolved_provider,
+        depth: None,
+        max_depth: None,
+        max_children: None,
+        timeout_sec: None,
+        system_prompt: sys_prompt,
+        parent_id: None,
+    };
+
+    match manager.spawn(req).await {
+        Ok(resp) => {
+            match manager.wait_for_completion(resp.id).await {
+                Ok(info) => {
+                    if json_output {
+                        println!("{}", serde_json::to_string_pretty(&info).unwrap_or_default());
+                    } else if let Some(ref output) = info.last_output {
+                        println!("{output}");
+                    }
+                    if info.status == agent::AgentStatus::Failed {
+                        1
+                    } else {
+                        0
+                    }
+                }
+                Err(e) => {
+                    eprintln!("Error: {e}");
+                    1
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            1
+        }
+    }
+}
+
 fn handle_role_command(cmd: RoleCommands, json_output: bool) -> Result<i32> {
     match cmd {
         RoleCommands::Create {
@@ -620,39 +769,59 @@ async fn handle_config_command(
             if json_output {
                 println!("{}", serde_json::to_string_pretty(config)?);
             } else {
-                println!("Default provider: {}", config.default.provider);
-                println!("Default model:    {}", config.default.model);
+                println!("Default provider:    {}", config.default.provider);
+                println!("Default model:       {}", config.default.model);
+                if let Some(ref sec) = config.default.secondary_provider {
+                    println!(
+                        "Secondary provider: {sec} (model: {})",
+                        config.default.secondary_model.as_deref().unwrap_or("provider default")
+                    );
+                }
+                if let Some(ref ter) = config.default.tertiary_provider {
+                    println!(
+                        "Tertiary provider:  {ter} (model: {})",
+                        config.default.tertiary_model.as_deref().unwrap_or("provider default")
+                    );
+                }
                 println!(
-                    "Default role:     {}",
+                    "Default role:        {}",
                     config.default.role.as_deref().unwrap_or("(none)")
                 );
                 println!(
-                    "Default tool:     {}",
+                    "Default tool:        {}",
                     config.default.tool.as_deref().unwrap_or("(none)")
                 );
                 println!();
-                println!("Server bind:      {}", config.server.bind);
-                println!("Server enabled:   {}", config.server.enabled);
+                println!("Server bind:         {}", config.server.bind);
+                println!("Server enabled:      {}", config.server.enabled);
                 println!();
                 println!("Limits:");
                 println!(
-                    "  Max concurrent agents: {}",
+                    "  Max concurrent agents:  {}",
                     config.limits.max_concurrent_agents
                 );
-                println!("  Max depth:             {}", config.limits.max_depth);
+                println!("  Max depth:              {}", config.limits.max_depth);
                 println!(
-                    "  Max children/parent:   {}",
+                    "  Max children/parent:    {}",
                     config.limits.max_children_per_parent
                 );
                 println!(
-                    "  Agent timeout:         {}s",
+                    "  Agent timeout:          {}s",
                     config.limits.agent_timeout_sec
+                );
+                println!(
+                    "  Agent poll interval:    {}ms",
+                    config.limits.agent_poll_interval_ms
                 );
                 println!();
                 println!("Providers:");
                 for (name, entry) in &config.provider {
                     let marker = if name == &config.default.provider {
-                        " (default)"
+                        " (primary)"
+                    } else if config.default.secondary_provider.as_deref() == Some(name) {
+                        " (secondary)"
+                    } else if config.default.tertiary_provider.as_deref() == Some(name) {
+                        " (tertiary)"
                     } else {
                         ""
                     };
@@ -792,8 +961,57 @@ async fn handle_config_command(
                         println!("Default tool set to: {value}");
                     }
                 }
+                "secondary-provider" | "secondary_provider" => {
+                    new_config.default.secondary_provider = Some(value.clone());
+                    config::save_config(&new_config)?;
+                    if json_output {
+                        println!("{}", json!({"secondary_provider": value}));
+                    } else {
+                        println!("Secondary provider set to: {value}");
+                    }
+                }
+                "secondary-model" | "secondary_model" => {
+                    new_config.default.secondary_model = Some(value.clone());
+                    config::save_config(&new_config)?;
+                    if json_output {
+                        println!("{}", json!({"secondary_model": value}));
+                    } else {
+                        println!("Secondary model set to: {value}");
+                    }
+                }
+                "tertiary-provider" | "tertiary_provider" => {
+                    new_config.default.tertiary_provider = Some(value.clone());
+                    config::save_config(&new_config)?;
+                    if json_output {
+                        println!("{}", json!({"tertiary_provider": value}));
+                    } else {
+                        println!("Tertiary provider set to: {value}");
+                    }
+                }
+                "tertiary-model" | "tertiary_model" => {
+                    new_config.default.tertiary_model = Some(value.clone());
+                    config::save_config(&new_config)?;
+                    if json_output {
+                        println!("{}", json!({"tertiary_model": value}));
+                    } else {
+                        println!("Tertiary model set to: {value}");
+                    }
+                }
+                "poll-interval" | "poll_interval" | "agent-poll-interval" | "agent_poll_interval" => {
+                    let ms: u64 = value.parse().map_err(|_| anyhow::anyhow!("poll-interval must be a number in milliseconds"))?;
+                    new_config.limits.agent_poll_interval_ms = ms;
+                    config::save_config(&new_config)?;
+                    if json_output {
+                        println!("{}", json!({"agent_poll_interval_ms": ms}));
+                    } else {
+                        println!("Agent poll interval set to: {ms}ms");
+                    }
+                }
                 other => {
-                    eprintln!("Unknown default key '{other}'. Valid keys: role, tool");
+                    eprintln!(
+                        "Unknown default key '{other}'. Valid keys: role, tool, \
+                         secondary-provider, secondary-model, tertiary-provider, tertiary-model, poll-interval"
+                    );
                     return Ok(1);
                 }
             }

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -3,6 +3,7 @@ mod anthropic;
 mod nvidia_nim;
 mod huggingface;
 mod bedrock;
+mod ollama;
 
 use anyhow::{bail, Result};
 use async_trait::async_trait;
@@ -15,6 +16,7 @@ pub use anthropic::AnthropicProvider;
 pub use nvidia_nim::NvidiaNimProvider;
 pub use huggingface::HuggingFaceProvider;
 pub use bedrock::BedrockProvider;
+pub use ollama::OllamaProvider;
 
 // ── Shared types ──────────────────────────────────────────────────────
 
@@ -94,6 +96,9 @@ pub fn build_provider(
         }
         "openai-compatible" | "openai_compatible" => Ok(Box::new(OpenAiProvider::new(
             name, &base_url, &model, &api_key, timeout, max_retries,
+        )?)),
+        "ollama" => Ok(Box::new(OllamaProvider::new(
+            name, &base_url, &model, timeout, max_retries,
         )?)),
         other => bail!("Unknown provider type: {other}"),
     }

--- a/src/provider/ollama.rs
+++ b/src/provider/ollama.rs
@@ -1,0 +1,152 @@
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::time::Duration;
+
+use super::{ChatMessage, ChatResponse, Provider};
+
+#[derive(Debug)]
+pub struct OllamaProvider {
+    name: String,
+    base_url: String,
+    model: String,
+    max_retries: u32,
+    http: Client,
+}
+
+impl OllamaProvider {
+    pub fn new(
+        name: &str,
+        base_url: &str,
+        model: &str,
+        timeout_secs: u32,
+        max_retries: u32,
+    ) -> Result<Self> {
+        let url = if base_url.is_empty() {
+            "http://localhost:11434".to_string()
+        } else {
+            base_url.trim_end_matches('/').to_string()
+        };
+
+        let http = Client::builder()
+            .timeout(Duration::from_secs(timeout_secs as u64))
+            .build()?;
+
+        Ok(Self {
+            name: name.to_string(),
+            base_url: url,
+            model: model.to_string(),
+            max_retries,
+            http,
+        })
+    }
+}
+
+#[async_trait]
+impl Provider for OllamaProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
+
+    async fn chat(
+        &self,
+        messages: &[ChatMessage],
+        system_prompt: Option<&str>,
+    ) -> Result<ChatResponse> {
+        // Ollama supports OpenAI-compatible /v1/chat/completions
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        let mut msgs: Vec<Value> = Vec::new();
+        if let Some(sys) = system_prompt {
+            msgs.push(json!({"role": "system", "content": sys}));
+        }
+        for m in messages {
+            msgs.push(json!({"role": &m.role, "content": &m.content}));
+        }
+
+        let body = json!({
+            "model": &self.model,
+            "messages": msgs,
+        });
+
+        let mut last_err = None;
+        for attempt in 0..=self.max_retries {
+            if attempt > 0 {
+                tokio::time::sleep(Duration::from_millis(500 * attempt as u64)).await;
+            }
+
+            match self
+                .http
+                .post(&url)
+                .header("Content-Type", "application/json")
+                .json(&body)
+                .send()
+                .await
+            {
+                Ok(r) if r.status().is_success() => {
+                    let data: Value = r.json().await?;
+                    return Ok(ChatResponse {
+                        content: data["choices"][0]["message"]["content"]
+                            .as_str()
+                            .unwrap_or("")
+                            .to_string(),
+                        tokens_used: data["usage"]["total_tokens"].as_u64(),
+                        finish_reason: data["choices"][0]["finish_reason"]
+                            .as_str()
+                            .map(String::from),
+                    });
+                }
+                Ok(r) => {
+                    let status = r.status();
+                    let text = r.text().await.unwrap_or_default();
+                    last_err = Some(format!("HTTP {status}: {text}"));
+                }
+                Err(e) => {
+                    last_err = Some(e.to_string());
+                }
+            }
+        }
+
+        bail!(
+            "Ollama provider '{}' failed after {} retries: {}",
+            self.name,
+            self.max_retries,
+            last_err.unwrap_or_default()
+        )
+    }
+
+    async fn health_check(&self) -> Result<String> {
+        let url = format!("{}/api/version", self.base_url);
+        match self.http.get(&url).send().await {
+            Ok(r) => Ok(format!("Ollama ({}): HTTP {}", self.name, r.status())),
+            Err(e) => Ok(format!("Ollama ({}): error — {}", self.name, e)),
+        }
+    }
+
+    async fn list_models(&self) -> Result<Vec<String>> {
+        // Ollama uses /api/tags to list locally available models
+        let url = format!("{}/api/tags", self.base_url);
+        let resp = self.http.get(&url).send().await?;
+
+        if !resp.status().is_success() {
+            bail!("Failed to list Ollama models: HTTP {}", resp.status());
+        }
+
+        let data: Value = resp.json().await?;
+        let mut models: Vec<String> = data["models"]
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|m| m["name"].as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        models.sort();
+        Ok(models)
+    }
+}


### PR DESCRIPTION
- Ollama provider: full OpenAI-compatible chat with /api/tags model listing and /api/version health check; defaults to http://localhost:11434
- Provider fallback chain: if primary provider fails, agents automatically retry secondary then tertiary providers (configurable via config set-default secondary-provider/tertiary-provider)
- Configurable poll interval: agent status polling defaults to 60s (was 500ms); set via config set-default poll-interval <ms> or limits.agent_poll_interval_ms in config.toml
- Direct execution mode: `mastercontrolprogram "prompt"` (no subcommand) spawns an agent, waits for completion, prints only the output to stdout, and exits; supports --role, --model, --provider, --json flags
- config show updated to display secondary/tertiary providers and poll interval with primary/secondary/tertiary markers

https://claude.ai/code/session_01HGFMd36gggicThKjQTgFbP